### PR TITLE
SymfonyYamlDumper: suport not only scalar options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "php": ">=7.2",
-        "readdle/crypto": "^0.0.3"
+        "readdle/crypto": "^0.0.3",
+        "symfony/yaml": "^4.3"
     },
     "autoload": {
         "exclude-from-classmap": ["*Test.php"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c76fbc64c7bc83b3b4ff8251a62e9df",
+    "content-hash": "012b539ec3b3d0c28fe14f1bf1024cda",
     "packages": [
         {
             "name": "readdle/crypto",
@@ -35,6 +35,123 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "time": "2018-06-25T15:50:55+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.12-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-08-06T08:03:45+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "41e16350a2a1c7383c4735aa2f9fce74cf3d1178"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/41e16350a2a1c7383c4735aa2f9fce74cf3d1178",
+                "reference": "41e16350a2a1c7383c4735aa2f9fce74cf3d1178",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-09-11T15:41:19+00:00"
         }
     ],
     "packages-dev": [
@@ -1738,64 +1855,6 @@
                 "standards"
             ],
             "time": "2019-09-26T23:12:26+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.12-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Fluix/Config/Dump/SymfonyYamlDumper.php
+++ b/src/Fluix/Config/Dump/SymfonyYamlDumper.php
@@ -6,24 +6,14 @@ namespace Fluix\Config\Dump;
 
 use Fluix\Config\Dumper;
 use Fluix\Config\File;
+use Symfony\Component\Yaml\Yaml;
 
 final class SymfonyYamlDumper implements Dumper
 {
     public function dump(File $file, array $values): void
     {
-        ob_start();
-        echo "parameters:\n";
-        foreach ($values as $k => $v) {
-            $val = "'{$v}'";
-            if (is_bool($v)) {
-                $val = $v ? 'true' : 'false';
-            } elseif (is_numeric($v)) {
-                $val = $v;
-            }
-            echo "    {$k}: {$val}\n";
-        }
-        
-        $file->write(ob_get_clean());
+        $string = Yaml::dump(["parameters" => $values], 2, 4, Yaml::DUMP_EXCEPTION_ON_INVALID_TYPE);
+        $file->write($string);
     }
     
     public function supports(Format $format): bool

--- a/src/Fluix/Config/Dump/SymfonyYamlDumperTest.php
+++ b/src/Fluix/Config/Dump/SymfonyYamlDumperTest.php
@@ -12,11 +12,44 @@ class SymfonyYamlDumperTest extends AbstractDumperTest
     {
         $expected = <<<JSON
 parameters:
-    qwe: 1
+    option1: value1
+    database: schema
+    boolean: false
+    'null': null
+    secret_value: secret-value-here
+    int: 397
+    object: { key: 21 }
+    array: [{ option31: test_env }]
+    nested: { child1: { child2: { env: test_env_value_json2 } } }
 JSON;
     
         return [
-            [["qwe" => 1], $expected],
+            [
+                [
+                    "option1"      => "value1",
+                    "database"     => "schema",
+                    "boolean"      => false,
+                    "null"         => null,
+                    "secret_value" => "secret-value-here",
+                    "int"          => 397,
+                    "object"       => [
+                        "key" => 21,
+                    ],
+                    "array"        => [
+                        [
+                            "option31" => "test_env",
+                        ],
+                    ],
+                    "nested"       => [
+                        "child1" => [
+                            "child2" => [
+                                "env" => "test_env_value_json2",
+                            ],
+                        ],
+                    ],
+                ],
+                $expected,
+            ],
         ];
     }
     


### PR DESCRIPTION
fixes #2 